### PR TITLE
(7) create validation directive for dni

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,1 @@
+{"directory":"lib"}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
-# rc-spanishIdValidator
-[Work in progress] This Angular library provides directives for the validation of common Spanish official ID documents.
+# rc-spanishIdValidator [Work in progress] 
+
+This is and AngularJS directive which provides validation for common Spanish official ID numbers like DNI or NIF.
+

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,24 @@
+module.exports = function(grunt) {
+
+  grunt.initConfig({
+    connect: {
+        server: {
+          options: {
+            hostname: 'localhost',
+            port: 8080,
+            keepalive:true,
+            open: {
+              target: 'http://localhost:8080/test/index.html'
+            }            
+          },
+        }
+     },
+  });
+
+  grunt.registerTask('default', ['web']);
+  
+  grunt.registerTask('web', ['connect:server']);
+  
+  grunt.loadNpmTasks('grunt-contrib-connect');
+  
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "ValidatorIdSpanish",
+  "version": "1.0.0",
+  "description": "[Work in progress] This Angular library provides directives for the validation of common Spanish official ID documents.",
+  "main": "gruntfile.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://AngelaPrades@github.com/anenchu/rc-spanishIdValidator.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/anenchu/rc-spanishIdValidator/issues"
+  },
+  "homepage": "https://github.com/anenchu/rc-spanishIdValidator",
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-contrib-connect": "^0.9.0"
+  }
+}

--- a/src/directives/namespace.js
+++ b/src/directives/namespace.js
@@ -1,0 +1,1 @@
+var directives = angular.module('app.directives',[]);

--- a/src/directives/rcdni.js
+++ b/src/directives/rcdni.js
@@ -1,4 +1,6 @@
-directives.directive('rcDni',['dniSemanticsValidationService','dniSyntaxValidationService',function(dniSemanticsValidationService,dniSyntaxValidationService){
+directives.directive('rcDni',['dniSemanticsValidationService','dniSyntaxValidationService',rcDni]);
+function rcDni(dniSemanticsValidationService,dniSyntaxValidationService)
+{
 	return{
 		require: 'ngModel',					
 		link: function (scope, elm, attrs, ctrl){	
@@ -16,9 +18,9 @@ directives.directive('rcDni',['dniSemanticsValidationService','dniSyntaxValidati
 			function validateDNISemantics(dni){
 				var isValid = dniSemanticsValidationService.validateDNISemantics(dni); 								
 				if (isValid){			
-					ctrl.$setValidity('pattern',true);
+					ctrl.$setValidity('dni',true);
 				}else{
-					ctrl.$setValidity('pattern',false);
+					ctrl.$setValidity('dni',false);
 				}
 				return isValid;
 			};
@@ -27,9 +29,9 @@ directives.directive('rcDni',['dniSemanticsValidationService','dniSyntaxValidati
             {
             	var isValid = dniSyntaxValidationService.validateDNISyntax(dni);
             	if (isValid){
-					ctrl.$setValidity('dni',true);
+					ctrl.$setValidity('pattern',true);
 				}else{
-					ctrl.$setValidity('dni',false);
+					ctrl.$setValidity('pattern',false);
 				}
             };
 
@@ -39,4 +41,4 @@ directives.directive('rcDni',['dniSemanticsValidationService','dniSyntaxValidati
             });
 		}
 	};
-}]);
+}

--- a/src/directives/rcdni.js
+++ b/src/directives/rcdni.js
@@ -1,0 +1,38 @@
+directives.directive('rcDni',['dniSemanticsValidationService','dniSyntaxValidationService',function(dniSemanticsValidationService,dniSyntaxValidationService){
+	return{
+		require: 'ngModel',					
+		link: function (scope, elm, attrs, ctrl){	
+			var validationToExecute = function (viewValue){
+				var currentTypedValue = viewValue;
+				validateDNI(currentTypedValue);
+			};
+
+			function validateDNI(dni){
+				validateDNISyntax(dni);
+				validateDNISemantics(dni);
+			}
+
+			function validateDNISemantics(dni){								
+				if (dniSemanticsValidationService.validateDNISemantics(currentTypedValue)){			
+					ctrl.$setValidity('pattern',true);
+				}else{
+					ctrl.$setValidity('pattern',false);
+				}
+			};
+
+			function validateDNISyntax(dni)
+            {
+            	if (dniSyntaxValidationService.validateDNISyntax(dni)){
+					ctrl.$setValidity('dni',true);
+				}else{
+					ctrl.$setValidity('dni',false);
+				}
+            };
+
+            ctrl.$parsers.unshift(function(viewValue){		
+            	validationToExecute(viewValue);
+            	return viewValue;
+            });
+		}
+	};
+}]);

--- a/src/directives/rcdni.js
+++ b/src/directives/rcdni.js
@@ -8,21 +8,25 @@ directives.directive('rcDni',['dniSemanticsValidationService','dniSyntaxValidati
 			};
 
 			function validateDNI(dni){
-				validateDNISyntax(dni);
-				validateDNISemantics(dni);
+				if (validateDNISyntax(dni)){
+					validateDNISemantics(dni);
+				}
 			}
 
-			function validateDNISemantics(dni){								
-				if (dniSemanticsValidationService.validateDNISemantics(currentTypedValue)){			
+			function validateDNISemantics(dni){
+				var isValid = dniSemanticsValidationService.validateDNISemantics(dni); 								
+				if (isValid){			
 					ctrl.$setValidity('pattern',true);
 				}else{
 					ctrl.$setValidity('pattern',false);
 				}
+				return isValid;
 			};
 
 			function validateDNISyntax(dni)
             {
-            	if (dniSyntaxValidationService.validateDNISyntax(dni)){
+            	var isValid = dniSyntaxValidationService.validateDNISyntax(dni);
+            	if (isValid){
 					ctrl.$setValidity('dni',true);
 				}else{
 					ctrl.$setValidity('dni',false);

--- a/src/services/dniSemanticsValidationService.js
+++ b/src/services/dniSemanticsValidationService.js
@@ -1,0 +1,14 @@
+(function(){
+	services.factory('dniSemanticsValidationService',[dniSemanticsValidationService]);
+
+	function dniSemanticsValidationService(){
+		function validateDNISemantics(dni) {
+			var c=dni.substr(0,1).toUpperCase();
+			return (c=='6');
+		};
+
+		return {
+			validateDNISemantics : validateDNISemantics
+		}
+	}
+})();

--- a/src/services/dniSemanticsValidationService.js
+++ b/src/services/dniSemanticsValidationService.js
@@ -4,7 +4,7 @@
 	function dniSemanticsValidationService(){
 		function validateDNISemantics(dni) {
 			var c=dni.substr(0,1).toUpperCase();
-			return (c=='6');
+			return (c=='4');
 		};
 
 		return {

--- a/src/services/dniSemanticsValidationService.js
+++ b/src/services/dniSemanticsValidationService.js
@@ -4,7 +4,7 @@
 	function dniSemanticsValidationService(){
 		function validateDNISemantics(dni) {
 			var c=dni.substr(0,1).toUpperCase();
-			return (c=='4');
+			return (c=='2');
 		};
 
 		return {

--- a/src/services/dniSyntaxValidationService.js
+++ b/src/services/dniSyntaxValidationService.js
@@ -4,7 +4,7 @@
 	function dniSyntaxValidationService(){
 		function validateDNISyntax(dni) {
 			var c=dni.substr(dni.length-1,1).toUpperCase();
-			return (c=='P');
+			return (c=='V');
 		};
 
 		return {

--- a/src/services/dniSyntaxValidationService.js
+++ b/src/services/dniSyntaxValidationService.js
@@ -1,0 +1,14 @@
+(function(){
+	services.factory('dniSyntaxValidationService',[dniSyntaxValidationService]);
+
+	function dniSyntaxValidationService(){
+		function validateDNISyntax(dni) {
+			var c=dni.substr(dni.length-1,1).toUpperCase();
+			return (c=='P');
+		};
+
+		return {
+			validateDNISyntax : validateDNISyntax
+		}
+	}
+})();

--- a/src/services/dniSyntaxValidationService.js
+++ b/src/services/dniSyntaxValidationService.js
@@ -4,7 +4,7 @@
 	function dniSyntaxValidationService(){
 		function validateDNISyntax(dni) {
 			var c=dni.substr(dni.length-1,1).toUpperCase();
-			return (c=='V');
+			return (c=='K');
 		};
 
 		return {

--- a/src/services/namespace.js
+++ b/src/services/namespace.js
@@ -1,0 +1,1 @@
+var services = angular.module('app.services',[]);

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <!-- JQuery, not 100% needed for this sample but just to clarify one case -->
+  <script src="../lib/jquery/dist/jquery.min.js"></script>
+
+  <!-- jasmine -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine.js"></script>
+  <!-- jasmine's html reporting code and css -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine-html.js"></script>
+  <link href="//cdnjs.cloudflare.com/ajax/libs/jasmine/1.3.1/jasmine.css" rel="stylesheet" />
+  <!-- angular itself -->
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular.js"></script>
+  <!-- angular's testing helpers -->
+  <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.11/angular-mocks.js"></script>
+  
+  <!-- your angular app code -->
+  <script src="../src/directives/namespace.js"></script>
+  <script src="../src/directives/rcdni.js"></script>
+  <script src="../src/services/namespace.js"></script>
+  <script src="../src/services/dniSemanticsValidationService.js"></script>
+  <script src="../src/services/dniSyntaxValidationService.js"></script>
+  <script src="mockDniController.js"></script>
+  
+  <!-- your Jasmine specs (tests) -->
+  <script src="rcdnispecs.js"></script>
+</head>
+
+<body>
+  <!-- bootstrap jasmine! -->
+  <script>
+  var jasmineEnv = jasmine.getEnv();
+  
+  // Tell it to add an Html Reporter
+  // this will add detailed HTML-formatted results
+  // for each spec ran.
+  jasmineEnv.addReporter(new jasmine.HtmlReporter());
+  
+  // Execute the tests!
+  jasmineEnv.execute();
+  </script>
+</body>
+
+
+</html>

--- a/test/karma.config.js
+++ b/test/karma.config.js
@@ -1,0 +1,80 @@
+// Karma configuration
+// Generated on Mon Mar 09 2015 21:06:52 GMT+0100 (Hora estándar romance)
+
+module.exports = function(config) {
+  config.set({
+
+    // base path that will be used to resolve all patterns (eg. files, exclude)
+    basePath: './',
+
+
+    // frameworks to use
+    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+    frameworks: ['jasmine'],
+
+
+    // list of files / patterns to load in the browser
+     files: [
+        // Third partie libraries      
+      '../lib/jquery/dist/jquery.min.js',                
+      '../lib/angular/angular.js',  
+      '../lib/angular-mocks/angular-mocks.js',  
+
+      // csc directive namespace
+      '../src/directives/namespace.js',
+
+      // csc service namespace
+      '../src/services/namespace.js',
+
+      // csc directives to test
+      '../src/directives/rcdni.js',
+
+      // test     
+      '*.js'
+
+    ],
+
+    // list of files to exclude
+    exclude: [
+    ],
+
+
+    // preprocess matching files before serving them to the browser
+    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+    preprocessors: {
+    },
+
+
+    // test results reporter to use
+    // possible values: 'dots', 'progress'
+    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+    reporters: ['progress'],
+
+
+    // web server port
+    port: 9876,
+
+
+    // enable / disable colors in the output (reporters and logs)
+    colors: true,
+
+
+    // level of logging
+    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,                            // esto sirve para vigilar, si cambio cualquier tipo de fichero, etc
+
+
+    // start these browsers
+    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+    browsers: ['Chrome'],
+
+
+    // Continuous Integration mode
+    // if true, Karma captures browsers, runs the tests and exits
+    singleRun: false
+  });
+};

--- a/test/mockdniController.js
+++ b/test/mockdniController.js
@@ -1,0 +1,3 @@
+angular.module('app.directives').controller('MockDniController',['$scope',function($scope){
+	$scope.fields = {dni: ""}
+}]);

--- a/test/mockdniController.js
+++ b/test/mockdniController.js
@@ -1,3 +1,3 @@
 angular.module('app.directives').controller('MockDniController',['$scope',function($scope){
-	$scope.fields = {dni: ""}
+	$scope.dni = "";
 }]);

--- a/test/rcdnispecs.js
+++ b/test/rcdnispecs.js
@@ -7,7 +7,8 @@ describe('Testing rcdni directive',function(){
       	form;
 
     beforeEach(function(){						
-    	module('app.directives');					
+    	module('app.directives');
+      module('app.services');					
     	html = '<form name="patientForm">' +		
     			'<input type=text id=dni name="dni" rc-dni="" ng-model="fields.dni" />'
     			'</form>';
@@ -25,13 +26,13 @@ describe('Testing rcdni directive',function(){
 	});
 		
 	it('Inform a valid DNI', function(){
-		form.dni.$setViewValue("68710415P");				
+		form.dni.$setViewValue("44591313V");				
 		scope.$digest();									
 		expect(form.dni.$valid).toBe(true);
 	});
 
 	it('Inform a wrong DNI',function(){
-		form.dni.$setViewValue("25691568H");
+		form.dni.$setViewValue("11111111A");
 		scope.$digest();
 		expect(form.dni.$valid).toBe(false);				
 	})

--- a/test/rcdnispecs.js
+++ b/test/rcdnispecs.js
@@ -1,0 +1,38 @@
+describe('Testing rcdni directive',function(){
+	var scope,										
+      	directive,
+      	compiled,
+      	html,
+      	ctrl,
+      	form;
+
+    beforeEach(function(){						
+    	module('app.directives');					
+    	html = '<form name="patientForm">' +		
+    			'<input type=text id=dni name="dni" rc-dni="" ng-model="fields.dni" />'
+    			'</form>';
+    	inject(function($compile, $rootScope, $controller){		
+    		scope = $rootScope.$new();						
+    		ctrl = $controller('MockDniController', {
+    			$scope: scope
+    		});
+    		elem = angular.element(html);						
+    		compiled = $compile(elem);				
+    		compiled(scope);									
+    		scope.$digest();									 				
+    		form = scope.patientForm;	
+    	});
+	});
+		
+	it('Inform a valid DNI', function(){
+		form.dni.$setViewValue("68710415P");				
+		scope.$digest();									
+		expect(form.dni.$valid).toBe(true);
+	});
+
+	it('Inform a wrong DNI',function(){
+		form.dni.$setViewValue("25691568H");
+		scope.$digest();
+		expect(form.dni.$valid).toBe(false);				
+	})
+});

--- a/test/rcdnispecs.js
+++ b/test/rcdnispecs.js
@@ -1,28 +1,28 @@
 describe('Testing rcdni directive',function(){
 	var scope,										
-      	directive,
-      	compiled,
-      	html,
-      	ctrl,
-      	form;
+      directive,
+      compiled,
+      html,
+      ctrl,
+      form;
 
-    beforeEach(function(){						
-    	module('app.directives');
-      module('app.services');					
-    	html = '<form name="patientForm">' +		
-    			'<input type=text id=dni name="dni" rc-dni="" ng-model="fields.dni" />'
-    			'</form>';
-    	inject(function($compile, $rootScope, $controller){		
-    		scope = $rootScope.$new();						
-    		ctrl = $controller('MockDniController', {
-    			$scope: scope
-    		});
-    		elem = angular.element(html);						
-    		compiled = $compile(elem);				
-    		compiled(scope);									
-    		scope.$digest();									 				
-    		form = scope.patientForm;	
-    	});
+  beforeEach(function(){						
+   	module('app.directives');
+    module('app.services');					
+   	html = '<form name="patientForm">' +		
+   			'<input type=text id=dni name="dni" rc-dni="" ng-model="dni" />' +
+   			'</form>';
+   	inject(function($compile, $rootScope, $controller){		
+   		scope = $rootScope.$new();						
+   		ctrl = $controller('MockDniController', {
+   			$scope: scope
+   		});
+   		elem = angular.element(html);						
+   		compiled = $compile(elem);				
+   		compiled(scope);									
+   		scope.$digest();									 				
+   		form = scope.patientForm;	
+   	});
 	});
 		
 	it('Inform a valid DNI', function(){

--- a/test/rcdnispecs.js
+++ b/test/rcdnispecs.js
@@ -26,13 +26,13 @@ describe('Testing rcdni directive',function(){
 	});
 		
 	it('Inform a valid DNI', function(){
-		form.dni.$setViewValue("44591313V");				
+		form.dni.$setViewValue("27904426K");				
 		scope.$digest();									
 		expect(form.dni.$valid).toBe(true);
 	});
 
 	it('Inform a wrong DNI',function(){
-		form.dni.$setViewValue("11111111A");
+		form.dni.$setViewValue("27904426T");
 		scope.$digest();
 		expect(form.dni.$valid).toBe(false);				
 	})


### PR DESCRIPTION
This pull requests refers to the first iteration of the implementation for the validation directive (preemptively denoted as "rc-dni") . Two "mock" services have been added to provide some basic functionality for testing. 
The code is also provided with a unit test to check that the implementation of the directive works as intended. The tests checks for both a valid and a non-valid Spanish document number
How to run the tests:
- Call bower install and npm install if needed to ensure that your libs package includes all the relevant dependencies
- Run grunt
- The browser should show that both tests have been successfully completed.
- Modify the DNI values (lines 29 and 35 in rcdnispecs.js to show different results

NOTES: 
- the mock services implemented simply check respectively if a given document number starts with 2 and ends with K. Thus, every document number following a 2***********K pattern will be registered as valid, regardless of length, syntax validity, etc.
- the first unit test expects a valid document number, the second test expects a wrong one.
